### PR TITLE
clarify 2.0.2 vulns fixed are in dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## TempFiles v2.0.2
 ### Fixed
-  - Vulnerabilities
+  - Vulnerabilities in dependencies
   - Broken dependabot-settings
 
 ### Updated


### PR DESCRIPTION
based on: https://github.com/manuth/TempFiles/commit/1b1f37b8c5aed6b5cafacd3dbecbb1161a0b864d